### PR TITLE
Nissix plugin scope-packages on @wix/ooi-hello-world

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-runtime": "^6.26.0",
     "express": "~4.15.0",
     "i18next": "^11.6.0",
-    "native-components-infra": "^1.0.147",
+    "@wix/native-components-infra": "^1.0.147",
     "prop-types": "~15.6.0",
     "react": "15.6.1",
     "react-dom": "15.6.1",
@@ -40,7 +40,7 @@
     "lint-staged": "^7.2.2",
     "jest-yoshi-preset": "^3.5.0",
     "puppeteer": "^1.1.0",
-    "yoshi": "^3.0.0",
+    "@wix/yoshi": "^3.0.0",
     "yoshi-style-dependencies": "^3.0.0",
     "@wix/wix-bootstrap-testkit": "latest",
     "@wix/wix-config-emitter": "latest"

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from 'native-components-infra/dist/es/src/HOC/withStyles/withStyles';
+import { withStyles } from '@wix/native-components-infra/dist/es/src/HOC/withStyles/withStyles';
 import styles from './styles.scss';
 
 function App(props) {

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-jest');
+module.exports = require('@wix/yoshi/config/wallaby-jest');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.569s



Output Log:
Migrating package "@wix/ooi-hello-world" in .


## Migration from non scope to @wix/scoped packages
> /tmp/9746097b065a3bd81ee79719696e4b57

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
src/viewer.js
```

